### PR TITLE
[EE-386] Fixes Resque Installing on Old Ruby Versions

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "redis-namespace", "~> 1.2"
   s.add_dependency "vegas", "~> 0.1.2"
-  s.add_dependency "sinatra", ">= 0.9.2"
+  s.add_dependency "sinatra", ">= 0.9.2", "< 2"
   s.add_dependency "multi_json", "~> 1.0"
   s.add_dependency "mono_logger", "~> 1.0"
 


### PR DESCRIPTION
What:
Adds a pessimistic constraint to the Sinatra dependency of our version of Resque. This prevents old versions of Ruby from breaking when we build and install a gem with a dependency that won't run on, for example, Ruby 1.9.3 on Ubuntu 12.04 neither of which will be updated

WHY:
We need to run Chef upgrades on instances with very old Ruby versions sometimes... TURNS OUT