### PR TITLE
[DASH-1383] Clamp redis dependency for Ruby 1.9

### DIFF
--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.24.1.flywheel'
+  Version = VERSION = '1.24.1.1.flywheel'
 end

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
+  s.add_dependency "redis", "< 4"
   s.add_dependency "redis-namespace", "~> 1.2"
   s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2", "< 2"


### PR DESCRIPTION
Restore servers are still running on 14.04, which uses Ruby 1.9. The
Redis gem made Ruby 2.0 a dependency starting in v4.0, so we need to use
a version that is older than that one.