### PR TITLE
[TECH-168] Clamp redis-namespace below 1.7

### DIFF
--- a/resque.gemspec
+++ b/resque.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.2"
+  s.add_dependency "redis-namespace", "~> 1.2", "< 1.7"
   s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2", "< 2"
   s.add_dependency "multi_json", "~> 1.0"


### PR DESCRIPTION
In 1.7, which was released yesterday, they decided to drop support for
Rubies older than 2.4.