### PR TITLE
[HOPS-5363] Remove activesupport and i18n gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "activesupport", "~> 3.0"
-gem "i18n"
 gem "json"
 gem "minitest", "4.7.0"
 gem "mocha", :require => false

--- a/Gemfiles/Gemfile.1.8.7
+++ b/Gemfiles/Gemfile.1.8.7
@@ -5,8 +5,6 @@ group :test do
   gem "rack-test", "~> 0.5"
   gem "mocha", :require => false
   gem "airbrake", "4.3.2"
-  gem "activesupport", "~> 3.0"
-  gem "i18n", "~> 0.6.0"
   gem "minitest", "4.7.0"
   gem "json"
   gem 'redis', '~> 3.0.0', '< 3.0.7'


### PR DESCRIPTION
Removes unused gems `activesupport` and `i18n` that are causing Dependabot alerts.  

In Chef, we are using a custom branch called `instance` which has already removed active support and has some other customizations in it.

This PR puts our gems in line with that branch, and newer branches of the main Resque repo which no longer use these gems. 

This change will have zero impact on Chef as it is already using the custom branch with this change. 
